### PR TITLE
fix/remove-missing-logos

### DIFF
--- a/packages/client/public/manifest.json
+++ b/packages/client/public/manifest.json
@@ -6,16 +6,6 @@
       "src": "favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
     }
   ],
   "start_url": ".",


### PR DESCRIPTION
- This branch removes references to logo192.png and logo512.png from the manifest.json file, addressing console errors related to missing assets.