### PR TITLE
fix/update-apple-touch-icon-in-index-html

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -5,8 +5,11 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Web site created using create-react-app" />
-    <link rel="apple-touch-icon" href="/logo192.png" />
+    <meta
+      name="description"
+      content="Web site created using create-react-app"
+    />
+    <link rel="apple-touch-icon" href="../client/public/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.json" />
     <title>Accommodation Search</title>
   </head>


### PR DESCRIPTION
- Replaced the incorrect logo reference in the `apple-touch-icon` in `index.html` with the correct asset.
- Ensured that the appropriate icon is set for better compatibility on Apple devices.
