### PR TITLE
fix/remove-unused-react-import-in-app

### DIFF
--- a/packages/client/src/app.tsx
+++ b/packages/client/src/app.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { HelmetProvider } from "react-helmet-async";
 import SearchPage from "./pages/SearchPage";
 import ItemDetailPage from "./pages/ItemDetailPage/ItemDetailPage";


### PR DESCRIPTION
- Removed the unnecessary `React` import from `app.tsx` as it's no longer needed with the React 17+ JSX transform.
