### PR TITLE
fix/reorder-meta-tags-and-preload-styles

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -2,16 +2,29 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
       content="Web site created using create-react-app"
     />
+
+    <title>Accommodation Search</title>
+
+    <!-- Favicon and icons -->
+    <link rel="icon" href="/favicon.ico" />
     <link rel="apple-touch-icon" href="../client/public/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.json" />
-    <title>Accommodation Search</title>
+
+    <!-- Preloading external styles early -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-alpha1/dist/css/bootstrap.min.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
+    />
   </head>
 
   <body>

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -1,6 +1,3 @@
-@import url(https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-alpha1/dist/css/bootstrap.min.css);
-@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css);
-
 html,
 body {
   width: 100%;


### PR DESCRIPTION
- Reordered meta tags in `index.html` for better structure and performance.
- Moved the `<title>` tag earlier in the document for improved SEO and browser rendering.
- Preloaded external styles (Bootstrap and FA) by moving them into `<link>` tags in the `<head>` to ensure they load early and prevent FOUC.
