### PR TITLE
feature/debounce-delay-config-as-prop

### DIFF
--- a/packages/client/src/pages/SearchPage.tsx
+++ b/packages/client/src/pages/SearchPage.tsx
@@ -9,8 +9,11 @@ const SearchPage = () => {
   const [searchValue, setSearchValue] = useState("");
   const [showClearBtn, setShowClearBtn] = useState(false);
 
-  // Use the debounce hook
-  const debouncedSearchValue = useDebounce(searchValue, 300);
+  // Define debounce delay as a prop or constant, allowing flexibility for future adjustment.
+  const debounceDelay = 200;
+
+  // Pass the configurable debounce delay to the useDebounce hook
+  const debouncedSearchValue = useDebounce(searchValue, debounceDelay);
 
   const { hotels, countries, cities, isLoading, isError } =
     useSearchData(debouncedSearchValue);


### PR DESCRIPTION
- Refactored the debounce delay in `SearchPage` to be a configurable prop.
- Improved flexibility and clarity by explicitly defining the delay as a variable instead of hardcoding it.