### PR TITLE
refactor/move-tolowercase-to-useSearchData

### DIFF
--- a/packages/client/src/hooks/useSearchData.ts
+++ b/packages/client/src/hooks/useSearchData.ts
@@ -6,13 +6,15 @@ import {
 } from "../services/apiService";
 
 const useSearchData = (searchValue: string) => {
+  const lowerCaseValue = searchValue.toLowerCase();
+
   const {
     data: hotels = [],
     isLoading: loadingHotels,
     isError: errorHotels,
   } = useQuery({
-    queryKey: ["hotels", searchValue],
-    queryFn: () => fetchAndFilterHotels(searchValue),
+    queryKey: ["hotels", lowerCaseValue],
+    queryFn: () => fetchAndFilterHotels(lowerCaseValue),
     enabled: !!searchValue,
   });
 
@@ -21,8 +23,8 @@ const useSearchData = (searchValue: string) => {
     isLoading: loadingCountries,
     isError: errorCountries,
   } = useQuery({
-    queryKey: ["countries", searchValue],
-    queryFn: () => fetchAndFilterCountries(searchValue),
+    queryKey: ["countries", lowerCaseValue],
+    queryFn: () => fetchAndFilterCountries(lowerCaseValue),
     enabled: !!searchValue,
   });
 
@@ -31,8 +33,8 @@ const useSearchData = (searchValue: string) => {
     isLoading: loadingCities,
     isError: errorCities,
   } = useQuery({
-    queryKey: ["cities", searchValue],
-    queryFn: () => fetchAndFilterCities(searchValue),
+    queryKey: ["cities", lowerCaseValue],
+    queryFn: () => fetchAndFilterCities(lowerCaseValue),
     enabled: !!searchValue,
   });
 

--- a/packages/client/src/services/apiService.ts
+++ b/packages/client/src/services/apiService.ts
@@ -1,19 +1,20 @@
 import { API_URL } from "../utils/apiConstants";
 import { Hotel, Country, City } from "../types/models";
 
-export const fetchAndFilterHotels = async (value: string) => {
+// Fetch and filter hotels
+export const fetchAndFilterHotels = async (lowerCaseValue: string) => {
   try {
     const hotelsData = await fetch(`${API_URL}/hotels`);
     if (!hotelsData.ok) throw new Error("Failed to fetch hotels");
     const hotels = (await hotelsData.json()) as Hotel[];
     return hotels.filter(
       ({ chain_name, hotel_name, city, country, state, zipcode }) =>
-        chain_name.toLowerCase().includes(value.toLowerCase()) ||
-        hotel_name.toLowerCase().includes(value.toLowerCase()) ||
-        city.toLowerCase().includes(value.toLowerCase()) ||
-        country.toLowerCase().includes(value.toLowerCase()) ||
-        state.toLowerCase().includes(value.toLowerCase()) ||
-        zipcode.includes(value)
+        chain_name.toLowerCase().includes(lowerCaseValue) ||
+        hotel_name.toLowerCase().includes(lowerCaseValue) ||
+        city.toLowerCase().includes(lowerCaseValue) ||
+        country.toLowerCase().includes(lowerCaseValue) ||
+        state.toLowerCase().includes(lowerCaseValue) ||
+        zipcode.includes(lowerCaseValue)
     );
   } catch (error) {
     console.error(error);
@@ -21,15 +22,16 @@ export const fetchAndFilterHotels = async (value: string) => {
   }
 };
 
-export const fetchAndFilterCountries = async (value: string) => {
+// Fetch and filter countries
+export const fetchAndFilterCountries = async (lowerCaseValue: string) => {
   try {
     const countriesData = await fetch(`${API_URL}/countries`);
     if (!countriesData.ok) throw new Error("Failed to fetch countries");
     const countries = (await countriesData.json()) as Country[];
     return countries.filter(
       ({ country, countryisocode }) =>
-        countryisocode.toLowerCase().includes(value.toLowerCase()) ||
-        country.toLowerCase().includes(value.toLowerCase())
+        countryisocode.toLowerCase().includes(lowerCaseValue) ||
+        country.toLowerCase().includes(lowerCaseValue)
     );
   } catch (error) {
     console.error(error);
@@ -37,13 +39,14 @@ export const fetchAndFilterCountries = async (value: string) => {
   }
 };
 
-export const fetchAndFilterCities = async (value: string) => {
+// Fetch and filter cities
+export const fetchAndFilterCities = async (lowerCaseValue: string) => {
   try {
     const citiesData = await fetch(`${API_URL}/cities`);
     if (!citiesData.ok) throw new Error("Failed to fetch cities");
     const cities = (await citiesData.json()) as City[];
     return cities.filter(({ name }) =>
-      name.toLowerCase().includes(value.toLowerCase())
+      name.toLowerCase().includes(lowerCaseValue)
     );
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
- Moved the `toLowerCase()` logic out of the fetch functions and into the `useSearchData` hook.
- The search value is now lower-cased once and passed to the data-fetching functions, improving efficiency and cleaning up the service logic.
