### PR TITLE
fix/dependency-issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       "dependencies": {
         "@tanstack/react-query": "^5.56.2",
         "@testing-library/react-hooks": "^8.0.1",
+        "react-dom": "^18.3.1",
         "react-helmet-async": "^2.0.5",
         "react-router-dom": "^6.26.2"
       },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@tanstack/react-query": "^5.56.2",
     "@testing-library/react-hooks": "^8.0.1",
+    "react-dom": "^18.3.1",
     "react-helmet-async": "^2.0.5",
     "react-router-dom": "^6.26.2"
   }


### PR DESCRIPTION
- Resolved dependency conflicts by installing react-dom@^18.0.0 with the --legacy-peer-deps flag to ensure compatibility with testing libraries.