### PR TITLE
refactor/remove-react-hooks-library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
       ],
       "dependencies": {
         "@tanstack/react-query": "^5.56.2",
-        "@testing-library/react-hooks": "^8.0.1",
         "express": "^4.21.0",
         "react-dom": "^18.3.1",
         "react-helmet-async": "^2.0.5",
@@ -21,6 +20,7 @@
         "serve-static": "^1.16.2"
       },
       "devDependencies": {
+        "@testing-library/react": "^16.0.1",
         "@types/node": "^22.5.5",
         "concurrently": "^8.2.2",
         "vitest": "^2.1.1"
@@ -144,6 +144,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
       "integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
+      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -1257,9 +1258,9 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.0.0.tgz",
-      "integrity": "sha512-guuxUKRWQ+FgNX0h0NS0FIq3Q3uLtWVpBzcLOggmfMoUpgBnzBzvLLd4fbm6yS8ydJd94cIfY4yP9qUQjM2KwQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.0.1.tgz",
+      "integrity": "sha512-dSmwJVtJXmku+iocRhWOUFbrERC76TX2Mnf0ATODz8brzAZrMBbzLwQixlBSanZxR6LddK3eiwpSFZgDET1URg==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5"
@@ -1279,35 +1280,6 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@testing-library/react-hooks": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz",
-      "integrity": "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "react-error-boundary": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.9.0 || ^17.0.0",
-        "react": "^16.9.0 || ^17.0.0",
-        "react-dom": "^16.9.0 || ^17.0.0",
-        "react-test-renderer": "^16.9.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-test-renderer": {
           "optional": true
         }
       }
@@ -1416,13 +1388,12 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.82",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.82.tgz",
-      "integrity": "sha512-wTW8Lu/PARGPFE8tOZqCvprOKg5sen/2uS03yKn2xbCDFP9oLncm7vMDQ2+dEQXHVIXrOpW6u72xUXEXO0ypSw==",
+      "version": "18.3.9",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.9.tgz",
+      "integrity": "sha512-+BpAVyTpJkNWWSSnaLBk6ePpHLOGJKnEQNbINNovPWzvEUyAe3e+/d494QdEh71RekM/qV7lw6jzf1HGrJyAtQ==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
-        "@types/scheduler": "^0.16",
         "csstype": "^3.0.2"
       }
     },
@@ -1434,12 +1405,6 @@
       "dependencies": {
         "@types/react": "*"
       }
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.8",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "dev": true
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
@@ -3463,7 +3428,7 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
       "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "jsbn": "1.1.0",
         "sprintf-js": "^1.1.3"
@@ -3561,7 +3526,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
       "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/jsdom": {
       "version": "24.1.0",
@@ -4554,21 +4519,6 @@
         "react": "^18.3.1"
       }
     },
-    "node_modules/react-error-boundary": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
-      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "react": ">=16.13.1"
-      }
-    },
     "node_modules/react-fast-compare": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
@@ -4639,7 +4589,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -4979,7 +4930,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -4989,7 +4940,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
       "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
@@ -5026,7 +4977,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -5802,16 +5753,6 @@
         "typescript": "^5.2.2",
         "vite": "^5.3.6",
         "vitest": "^2.0.1"
-      }
-    },
-    "packages/client/node_modules/@types/react": {
-      "version": "18.3.8",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.8.tgz",
-      "integrity": "sha512-syBUrW3/XpnW4WJ41Pft+I+aPoDVbrBVQGEnbD7NijDGlVC+8gV/XKRY+7vMDlfPpbwYt0l1vd/Sj8bJGMbs9Q==",
-      "dev": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
     "api-no-watch": "npm run -w api dev:no-watch"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.0.1",
     "@types/node": "^22.5.5",
     "concurrently": "^8.2.2",
     "vitest": "^2.1.1"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.56.2",
-    "@testing-library/react-hooks": "^8.0.1",
     "express": "^4.21.0",
     "react-dom": "^18.3.1",
     "react-helmet-async": "^2.0.5",

--- a/packages/client/src/hooks/__tests__/unit/useDebounceUnit.test.ts
+++ b/packages/client/src/hooks/__tests__/unit/useDebounceUnit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"; // Importing testing utilities from Vitest
-import { renderHook, act } from "@testing-library/react-hooks"; // Importing functions to test custom hooks
+import { renderHook, act } from "@testing-library/react"; // Importing functions to test custom hooks
 import useDebounce from "../../useDebounce"; // Importing the useDebounce hook to be tested
 
 describe("useDebounce", () => {

--- a/packages/client/src/hooks/__tests__/unit/useSearchDataUnit.test.ts
+++ b/packages/client/src/hooks/__tests__/unit/useSearchDataUnit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"; // Importing testing utilities
-import { renderHook } from "@testing-library/react-hooks"; // Function to render custom hooks for testing
+import { renderHook } from "@testing-library/react"; // Importing functions to test custom hooks
 import { useQuery } from "@tanstack/react-query"; // Importing the useQuery hook for mocking
 import useSearchData from "../../useSearchData"; // Importing the custom hook to test
 

--- a/packages/client/src/hooks/__tests__/unit/useSearchLogicUnit.test.ts
+++ b/packages/client/src/hooks/__tests__/unit/useSearchLogicUnit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"; // Importing testing utilities
-import { renderHook, act } from "@testing-library/react-hooks"; // Function to render custom hooks for testing
+import { renderHook, act } from "@testing-library/react"; // Use renderHook from @testing-library/react
 import { useSearchLogic } from "../../useSearchLogic"; // Importing the custom hook to test
 import useDebounce from "../../useDebounce"; // Mock this hook
 import useSearchData from "../../useSearchData"; // Mock this hook


### PR DESCRIPTION
Refactor test suite to remove dependency on @testing-library/react-hooks and replace it with @testing-library/react for testing custom hooks. Updated test cases to ensure compatibility with React 18. This change enhances maintainability and aligns with the latest testing practices for React applications.
