### PR TITLE
fix/micromatch-vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3761,9 +3761,9 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
         "braces": "^3.0.3",


### PR DESCRIPTION
Address moderate severity vulnerability in the `micromatch` package related to ReDoS. Upgraded `micromatch` to version 4.0.8 to mitigate this security risk. This change enhances the security posture of the project by addressing known vulnerabilities.
